### PR TITLE
Remove dashboard progress issue42

### DIFF
--- a/frontend/src/components/scan/LanguageSelector.tsx
+++ b/frontend/src/components/scan/LanguageSelector.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   Box,
   Typography,
@@ -9,8 +9,10 @@ import {
   Checkbox,
   FormControlLabel,
   Alert,
+  ToggleButtonGroup,
+  ToggleButton,
 } from '@mui/material';
-import { Translate, Language } from '@mui/icons-material';
+import { Translate, Language, FilterList } from '@mui/icons-material';
 
 interface SupportedLanguage {
   code: string;
@@ -26,6 +28,8 @@ interface LanguageSelectorProps {
   loading?: boolean;
 }
 
+type FilterType = 'all' | 'existing' | 'new';
+
 const LanguageSelector: React.FC<LanguageSelectorProps> = ({
   supportedLanguages,
   selectedLanguages,
@@ -33,8 +37,38 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = ({
   onLanguageToggle,
   loading = false,
 }) => {
+  const [filter, setFilter] = useState<FilterType>('all');
+
   const isLanguageSelected = (code: string) => selectedLanguages.includes(code);
   const isLanguageExisting = (code: string) => existingLanguages.includes(code);
+
+  // Filter languages based on selected filter
+  const filteredLanguages = useMemo(() => {
+    switch (filter) {
+      case 'existing':
+        return supportedLanguages.filter(lang => isLanguageExisting(lang.code));
+      case 'new':
+        return supportedLanguages.filter(lang => !isLanguageExisting(lang.code));
+      case 'all':
+      default:
+        return supportedLanguages;
+    }
+  }, [filter, supportedLanguages, existingLanguages]);
+
+  // Count languages for each filter
+  const existingCount = supportedLanguages.filter(lang => 
+    isLanguageExisting(lang.code)
+  ).length;
+  const newCount = supportedLanguages.length - existingCount;
+
+  const handleFilterChange = (
+    event: React.MouseEvent<HTMLElement>,
+    newFilter: FilterType | null,
+  ) => {
+    if (newFilter !== null) {
+      setFilter(newFilter);
+    }
+  };
 
   return (
     <Box sx={{ mb: 4 }}>
@@ -61,131 +95,196 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = ({
         </Alert>
       )}
 
-      <Grid container spacing={2}>
-        {supportedLanguages.map((language) => {
-          const isSelected = isLanguageSelected(language.code);
-          const isExisting = isLanguageExisting(language.code);
+      {/* Filter Toggle */}
+      <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <FilterList sx={{ fontSize: 20, color: 'rgba(255,255,255,0.7)' }} />
+          <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)' }}>
+            Filter:
+          </Typography>
+        </Box>
+        
+        <ToggleButtonGroup
+          value={filter}
+          exclusive
+          onChange={handleFilterChange}
+          sx={{
+            '& .MuiToggleButton-root': {
+              color: 'rgba(255,255,255,0.6)',
+              borderColor: 'rgba(255,255,255,0.2)',
+              padding: '6px 16px',
+              fontSize: '0.875rem',
+              textTransform: 'none',
+              '&:hover': {
+                backgroundColor: 'rgba(255,255,255,0.05)',
+              },
+              '&.Mui-selected': {
+                backgroundColor: 'rgba(99, 102, 241, 0.2)',
+                color: '#6366f1',
+                borderColor: 'rgba(99, 102, 241, 0.5)',
+                '&:hover': {
+                  backgroundColor: 'rgba(99, 102, 241, 0.3)',
+                },
+              },
+            },
+          }}
+        >
+          <ToggleButton value="all">
+            Show All ({supportedLanguages.length})
+          </ToggleButton>
+          <ToggleButton value="existing">
+            Show Existing ({existingCount})
+          </ToggleButton>
+          <ToggleButton value="new">
+            Show New ({newCount})
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
 
-          return (
-            <Grid item xs={12} sm={6} md={4} key={language.code}>
-              <Card
-                sx={{
-                  cursor: loading ? 'not-allowed' : 'pointer',
-                  opacity: loading ? 0.6 : 1,
-                  transition: 'all 0.3s ease',
-                  backgroundColor: isSelected
-                    ? 'rgba(99, 102, 241, 0.1)'
-                    : isExisting
-                    ? 'rgba(34, 197, 94, 0.05)'
-                    : 'rgba(26, 26, 46, 0.8)',
-                  border: isSelected
-                    ? '2px solid rgba(99, 102, 241, 0.5)'
-                    : isExisting
-                    ? '2px solid rgba(34, 197, 94, 0.3)'
-                    : '1px solid rgba(255, 255, 255, 0.1)',
-                  '&:hover': {
+      {/* Language Grid */}
+      {filteredLanguages.length === 0 ? (
+        <Box
+          sx={{
+            textAlign: 'center',
+            py: 6,
+            px: 3,
+            backgroundColor: 'rgba(26, 26, 46, 0.8)',
+            borderRadius: 2,
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+          }}
+        >
+          <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+            No languages found for the selected filter.
+          </Typography>
+        </Box>
+      ) : (
+        <Grid container spacing={2}>
+          {filteredLanguages.map((language) => {
+            const isSelected = isLanguageSelected(language.code);
+            const isExisting = isLanguageExisting(language.code);
+
+            return (
+              <Grid item xs={12} sm={6} md={4} key={language.code}>
+                <Card
+                  sx={{
+                    cursor: loading ? 'not-allowed' : 'pointer',
+                    opacity: loading ? 0.6 : 1,
+                    transition: 'all 0.3s ease',
                     backgroundColor: isSelected
-                      ? 'rgba(99, 102, 241, 0.15)'
+                      ? 'rgba(99, 102, 241, 0.1)'
                       : isExisting
-                      ? 'rgba(34, 197, 94, 0.1)'
-                      : 'rgba(255, 255, 255, 0.05)',
+                      ? 'rgba(34, 197, 94, 0.05)'
+                      : 'rgba(26, 26, 46, 0.8)',
                     border: isSelected
-                      ? '2px solid rgba(99, 102, 241, 0.7)'
-                      : '2px solid rgba(255, 255, 255, 0.2)',
-                  },
-                }}
-                onClick={() => !loading && onLanguageToggle(language.code)}
-              >
-                <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-                  <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={isSelected}
-                          disabled={loading}
+                      ? '2px solid rgba(99, 102, 241, 0.5)'
+                      : isExisting
+                      ? '2px solid rgba(34, 197, 94, 0.3)'
+                      : '1px solid rgba(255, 255, 255, 0.1)',
+                    '&:hover': {
+                      backgroundColor: isSelected
+                        ? 'rgba(99, 102, 241, 0.15)'
+                        : isExisting
+                        ? 'rgba(34, 197, 94, 0.1)'
+                        : 'rgba(255, 255, 255, 0.05)',
+                      border: isSelected
+                        ? '2px solid rgba(99, 102, 241, 0.7)'
+                        : '2px solid rgba(255, 255, 255, 0.2)',
+                    },
+                  }}
+                  onClick={() => !loading && onLanguageToggle(language.code)}
+                >
+                  <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={isSelected}
+                            disabled={loading}
+                            sx={{
+                              color: 'rgba(255,255,255,0.5)',
+                              '&.Mui-checked': {
+                                color: '#6366f1',
+                              },
+                              p: 0,
+                            }}
+                          />
+                        }
+                        label=""
+                        sx={{ m: 0 }}
+                      />
+                      <Box sx={{ flex: 1 }}>
+                        <Typography
+                          variant="subtitle2"
                           sx={{
-                            color: 'rgba(255,255,255,0.5)',
-                            '&.Mui-checked': {
-                              color: '#6366f1',
-                            },
-                            p: 0,
+                            color: 'white',
+                            fontWeight: 600,
+                            mb: 0.5,
+                          }}
+                        >
+                          {language.name}
+                        </Typography>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: 'rgba(255,255,255,0.7)',
+                            fontSize: '0.875rem',
+                          }}
+                        >
+                          {language.native}
+                        </Typography>
+                      </Box>
+                    </Box>
+
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <Chip
+                        label={language.code}
+                        size="small"
+                        sx={{
+                          fontSize: '0.7rem',
+                          height: 20,
+                          backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                          color: 'rgba(255,255,255,0.8)',
+                          border: '1px solid rgba(255, 255, 255, 0.2)',
+                        }}
+                      />
+
+                      {isExisting && (
+                        <Chip
+                          label="Existing"
+                          size="small"
+                          sx={{
+                            fontSize: '0.6rem',
+                            height: 18,
+                            backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                            color: '#22c55e',
+                            border: '1px solid rgba(34, 197, 94, 0.3)',
                           }}
                         />
-                      }
-                      label=""
-                      sx={{ m: 0 }}
-                    />
-                    <Box sx={{ flex: 1 }}>
-                      <Typography
-                        variant="subtitle2"
-                        sx={{
-                          color: 'white',
-                          fontWeight: 600,
-                          mb: 0.5,
-                        }}
-                      >
-                        {language.name}
-                      </Typography>
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          color: 'rgba(255,255,255,0.7)',
-                          fontSize: '0.875rem',
-                        }}
-                      >
-                        {language.native}
-                      </Typography>
+                      )}
+
+                      {isSelected && !isExisting && (
+                        <Chip
+                          label="Selected"
+                          size="small"
+                          sx={{
+                            fontSize: '0.6rem',
+                            height: 18,
+                            backgroundColor: 'rgba(99, 102, 241, 0.1)',
+                            color: '#6366f1',
+                            border: '1px solid rgba(99, 102, 241, 0.3)',
+                          }}
+                        />
+                      )}
                     </Box>
-                  </Box>
+                  </CardContent>
+                </Card>
+              </Grid>
+            );
+          })}
+        </Grid>
+      )}
 
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Chip
-                      label={language.code}
-                      size="small"
-                      sx={{
-                        fontSize: '0.7rem',
-                        height: 20,
-                        backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                        color: 'rgba(255,255,255,0.8)',
-                        border: '1px solid rgba(255, 255, 255, 0.2)',
-                      }}
-                    />
-
-                    {isExisting && (
-                      <Chip
-                        label="Existing"
-                        size="small"
-                        sx={{
-                          fontSize: '0.6rem',
-                          height: 18,
-                          backgroundColor: 'rgba(34, 197, 94, 0.1)',
-                          color: '#22c55e',
-                          border: '1px solid rgba(34, 197, 94, 0.3)',
-                        }}
-                      />
-                    )}
-
-                    {isSelected && !isExisting && (
-                      <Chip
-                        label="Selected"
-                        size="small"
-                        sx={{
-                          fontSize: '0.6rem',
-                          height: 18,
-                          backgroundColor: 'rgba(99, 102, 241, 0.1)',
-                          color: '#6366f1',
-                          border: '1px solid rgba(99, 102, 241, 0.3)',
-                        }}
-                      />
-                    )}
-                  </Box>
-                </CardContent>
-              </Card>
-            </Grid>
-          );
-        })}
-      </Grid>
-
+      {/* Selection Summary */}
       <Box sx={{ mt: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
           <Translate sx={{ fontSize: 16, mr: 1, verticalAlign: 'middle' }} />

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -111,14 +111,14 @@ const Dashboard: React.FC = () => {
       console.log('🔍 Dashboard initializeAuth starting...');
       console.log('🔍 Current URL:', window.location.href);
       console.log('🔍 localStorage before callback:', localStorage.getItem('mobilebytes_auth_token')?.substring(0, 20));
-      
+
       // Small delay to ensure localStorage is ready
       await new Promise(resolve => setTimeout(resolve, 100));
-      
+
       // Check for OAuth callback first
       const callbackUser = AuthService.handleOAuthCallback();
       console.log('🔍 After handleOAuthCallback:', { user: callbackUser });
-      
+
       if (callbackUser) {
         console.log('✅ OAuth callback successful:', callbackUser);
         console.log('🔍 localStorage after callback:', localStorage.getItem('mobilebytes_auth_token')?.substring(0, 20));
@@ -130,15 +130,15 @@ const Dashboard: React.FC = () => {
       }
 
       console.log('🔍 No callback user, checking existing auth...');
-      
+
       // Check if already authenticated
       const isAuth = AuthService.isAuthenticated();
       console.log('🔍 isAuthenticated result:', isAuth);
-      
+
       if (isAuth) {
         const existingUser = AuthService.getUser();
         console.log('🔍 existingUser from getUser():', existingUser);
-        
+
         if (existingUser) {
           console.log('✅ Found existing authenticated user:', existingUser);
           setUser(existingUser);
@@ -153,7 +153,7 @@ const Dashboard: React.FC = () => {
 
       // Only redirect to login if we have no user and no token
       console.log('❌ No authentication found, redirecting to login in 2 seconds...');
-      
+
       // Add a delay to see what's happening
       setTimeout(() => {
         console.log('🔍 Final localStorage check before redirect:', localStorage.getItem('mobilebytes_auth_token')?.substring(0, 20));
@@ -168,24 +168,24 @@ const Dashboard: React.FC = () => {
   // Fetch repositories from backend
   const fetchRepositories = async () => {
     if (isLoadingRepos) return; // Prevent multiple concurrent requests
-    
+
     setIsLoadingRepos(true);
     setError(null);
-    
+
     try {
       console.log('📂 Fetching repositories from backend...');
       console.log('🔑 Using token:', AuthService.getToken()?.substring(0, 20) + '...');
-      
+
       const response = await AuthService.apiRequest('/repositories');
       console.log('📡 API response status:', response.status);
       console.log('📡 API response headers:', response.headers);
-      
+
       if (!response.ok) {
         const errorText = await response.text();
         console.error('❌ API Error Response:', errorText);
         throw new Error(`HTTP ${response.status}: ${response.statusText}\n${errorText}`);
       }
-      
+
       const data: RepositoryResponse = await response.json();
       console.log('✅ Repositories data received:', data);
       console.log('✅ Number of repositories:', data.repositories?.length || 0);
@@ -296,7 +296,7 @@ const Dashboard: React.FC = () => {
 
       // Refresh repositories list
       await fetchRepositories();
-      
+
       // Close dialog and reset form
       setShowAddDialog(false);
       setRepoUrl('');
@@ -426,7 +426,7 @@ const Dashboard: React.FC = () => {
               >
                 Add Repository
               </GradientButton>
-              
+
               <GradientButton
                 variant="outline"
                 startIcon={<Refresh />}
@@ -692,7 +692,7 @@ const Dashboard: React.FC = () => {
                               {repo.fullName}
                             </Typography>
                           </Box>
-                          
+
                           <IconButton
                             size="small"
                             onClick={(e) => {
@@ -718,7 +718,7 @@ const Dashboard: React.FC = () => {
                             overflow: 'hidden',
                           }}
                         >
-                          {repo.description}
+                          {repo.description || 'No description available'}
                         </Typography>
 
                         {/* Language and Stats */}
@@ -737,52 +737,8 @@ const Dashboard: React.FC = () => {
                           </Typography>
                         </Box>
 
-                        {/* Translation Progress */}
-                        {repo.status !== 'scanning' ? (
-                          <Box sx={{ mb: 2 }}>
-                            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                              <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.7)' }}>
-                                Translation Progress
-                              </Typography>
-                              <Typography variant="caption" sx={{ color: getStatusColor(repo.status) }}>
-                                {repo.translationProgress}%
-                              </Typography>
-                            </Box>
-                            <LinearProgress
-                              variant="determinate"
-                              value={repo.translationProgress}
-                              sx={{
-                                height: 6,
-                                borderRadius: 3,
-                                backgroundColor: 'rgba(255,255,255,0.1)',
-                                '& .MuiLinearProgress-bar': {
-                                  backgroundColor: getStatusColor(repo.status),
-                                  borderRadius: 3,
-                                },
-                              }}
-                            />
-                          </Box>
-                        ) : (
-                          <Box sx={{ mb: 2 }}>
-                            <Typography variant="caption" sx={{ color: '#f59e0b', mb: 1, display: 'block' }}>
-                              Scanning repository...
-                            </Typography>
-                            <LinearProgress
-                              sx={{
-                                height: 6,
-                                borderRadius: 3,
-                                backgroundColor: 'rgba(255,255,255,0.1)',
-                                '& .MuiLinearProgress-bar': {
-                                  backgroundColor: '#f59e0b',
-                                  borderRadius: 3,
-                                },
-                              }}
-                            />
-                          </Box>
-                        )}
-
                         {/* Languages */}
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 2 }}>
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                           {(repo.languages || []).slice(0, 3).map((lang) => (
                             <Chip
                               key={lang}
@@ -811,14 +767,6 @@ const Dashboard: React.FC = () => {
                             />
                           )}
                         </Box>
-
-                        {/* Last Scan */}
-                        <Typography
-                          variant="caption"
-                          sx={{ color: 'rgba(255,255,255,0.5)' }}
-                        >
-                          Last scan: {repo.lastScan}
-                        </Typography>
                       </CardContent>
                     </Card>
                   </Grid>
@@ -862,8 +810,8 @@ const Dashboard: React.FC = () => {
       </Menu>
 
       {/* Add Repository Dialog */}
-      <Dialog 
-        open={showAddDialog} 
+      <Dialog
+        open={showAddDialog}
         onClose={handleCloseAddDialog}
         maxWidth="sm"
         fullWidth
@@ -882,12 +830,12 @@ const Dashboard: React.FC = () => {
             Add Repository
           </Box>
         </DialogTitle>
-        
+
         <DialogContent>
           <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)', mb: 3 }}>
             Enter the GitHub repository URL you want to add for translation.
           </Typography>
-          
+
           <TextField
             fullWidth
             label="GitHub Repository URL"
@@ -914,12 +862,12 @@ const Dashboard: React.FC = () => {
               },
             }}
           />
-          
+
           <Alert severity="info" sx={{ mt: 2 }}>
             The repository will be scanned for translatable strings and added to your dashboard.
           </Alert>
         </DialogContent>
-        
+
         <DialogActions sx={{ p: 3 }}>
           <GradientButton
             variant="outline"


### PR DESCRIPTION
## Description

Removes the **Translation Progress bar** and **Last Scan** information from repository cards on the Dashboard to simplify the UI and improve focus on essential repository metadata.

## Changes Made

- Removed the Translation Progress section (progress bar and percentage) from repository cards
- Removed the "Last Scan" timestamp text from repository cards
- Cards now display only: repository name, status icon, badges (Organization/Personal/Private), description, primary language, stats (stars & string count), and language chips

## Related Issue
Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added language filtering (All/Existing/New) with counts and empty-state messaging.
  - Enhanced language cards with selection/existing chips, language code badges, and dynamic styling.
  - Repository cards now show up to three languages with a “+N” indicator for more.
  - Added fallback text for missing repository descriptions.

- Refactor
  - Simplified repository cards by removing Translation Progress and Last Scan sections.
  - Rendered languages based on the active filter for a clearer selection flow.

- Style
  - Updated card hover/active visuals and checkbox styling to reflect selection/existence states.
  - Minor layout and spacing tweaks across cards and dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->