### PR TITLE
fix: resolve authentication state persistence issue after login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,27 +77,32 @@ function App() {
 
   const checkAuthState = () => {
     setIsAuthChecking(true);
-    
-    // First, check if this is an OAuth callback
-    const callbackUser = AuthService.handleOAuthCallback();
-    
-    if (callbackUser) {
-      console.log('✅ OAuth callback successful, user:', callbackUser);
-      setUser(callbackUser);
-      setIsAuthChecking(false);
-      return;
-    }
 
-    // If not a callback, check if user is already authenticated
-    if (AuthService.isAuthenticated()) {
-      const storedUser = AuthService.getUser();
-      console.log('✅ User already authenticated:', storedUser);
-      setUser(storedUser);
-    } else {
-      console.log('ℹ️ No authenticated user found');
+    try {
+      // First, check if this is an OAuth callback
+      const callbackUser = AuthService.handleOAuthCallback();
+
+      if (callbackUser) {
+        console.log('✅ OAuth callback successful, user:', callbackUser);
+        setUser(callbackUser);
+        setIsAuthChecking(false);
+        return;
+      }
+
+      // If not a callback, check if user is already authenticated
+      if (AuthService.isAuthenticated()) {
+        const storedUser = AuthService.getUser();
+        console.log('✅ User already authenticated:', storedUser);
+        setUser(storedUser);
+      } else {
+        console.log('ℹ️ No authenticated user found');
+        setUser(null);
+      }
+    } catch (error) {
+      console.error('❌ Error checking authentication state:', error);
       setUser(null);
     }
-    
+
     setIsAuthChecking(false);
   };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
 
@@ -67,22 +67,64 @@ const theme = createTheme({
 });
 
 function App() {
-  const [user, setUser] = React.useState(AuthService.getUser());
+  const [user, setUser] = useState(AuthService.getUser());
+  const [isAuthChecking, setIsAuthChecking] = useState(true);
 
-  React.useEffect(() => {
-    const handleAuthChange = () => {
-      setUser(AuthService.getUser());
-    };
-
-    // Listen for auth changes (if you implement an event system)
-    // For now, we'll just check periodically or on mount
-    handleAuthChange();
+  useEffect(() => {
+    console.log('🔄 App mounting - checking authentication state...');
+    checkAuthState();
   }, []);
 
+  const checkAuthState = () => {
+    setIsAuthChecking(true);
+    
+    // First, check if this is an OAuth callback
+    const callbackUser = AuthService.handleOAuthCallback();
+    
+    if (callbackUser) {
+      console.log('✅ OAuth callback successful, user:', callbackUser);
+      setUser(callbackUser);
+      setIsAuthChecking(false);
+      return;
+    }
+
+    // If not a callback, check if user is already authenticated
+    if (AuthService.isAuthenticated()) {
+      const storedUser = AuthService.getUser();
+      console.log('✅ User already authenticated:', storedUser);
+      setUser(storedUser);
+    } else {
+      console.log('ℹ️ No authenticated user found');
+      setUser(null);
+    }
+    
+    setIsAuthChecking(false);
+  };
+
   const handleLogout = async () => {
+    console.log('🚪 Logging out...');
     await AuthService.logout();
     setUser(null);
   };
+
+  // Show loading state while checking authentication
+  if (isAuthChecking) {
+    return (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <div style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+          background: '#0f0f23',
+          color: 'white'
+        }}>
+          <div>Checking authentication...</div>
+        </div>
+      </ThemeProvider>
+    );
+  }
 
   return (
     <ThemeProvider theme={theme}>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+// frontend/src/components/layout/Header.tsx
+import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { AuthService, User } from '../../utils/auth';
+import { User } from '../../utils/auth';
 import {
   Box,
   Container,
@@ -26,40 +27,10 @@ interface HeaderProps {
   onLogout?: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ user: propUser, onLogout }) => {
+const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  
-  // Internal state to handle authentication state
-  const [internalUser, setInternalUser] = useState<User | null>(propUser || null);
-
-  // Sync with prop changes and verify authentication
-  useEffect(() => {
-    if (propUser) {
-      setInternalUser(propUser);
-    } else {
-      // Double-check authentication state if no user prop provided
-      if (AuthService.isAuthenticated()) {
-        const user = AuthService.getUser();
-        setInternalUser(user);
-      } else {
-        setInternalUser(null);
-      }
-    }
-  }, [propUser]);
-
-  // Refresh user state when location changes (helpful for OAuth redirects)
-  useEffect(() => {
-    const checkAuth = () => {
-      if (AuthService.isAuthenticated() && !internalUser) {
-        const user = AuthService.getUser();
-        setInternalUser(user);
-      }
-    };
-    
-    checkAuth();
-  }, [location.pathname]);
 
   const handleUserMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -73,8 +44,6 @@ const Header: React.FC<HeaderProps> = ({ user: propUser, onLogout }) => {
     handleUserMenuClose();
     onLogout?.();
   };
-
-  const user = internalUser; // Use internal user state
 
   const navItems = [
     { label: 'Home', path: '/', icon: <Home sx={{ fontSize: 20 }} /> },

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { AuthService, User } from '../../utils/auth';
 import {
   Box,
   Container,
@@ -16,24 +17,49 @@ import {
   GitHub,
   Dashboard,
   Settings,
-  AccountCircle,
   Logout,
   Home,
 } from '@mui/icons-material';
 
 interface HeaderProps {
-  user?: {
-    name: string;
-    avatar: string;
-    username: string;
-  } | null;
+  user?: User | null;
   onLogout?: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
+const Header: React.FC<HeaderProps> = ({ user: propUser, onLogout }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  
+  // Internal state to handle authentication state
+  const [internalUser, setInternalUser] = useState<User | null>(propUser || null);
+
+  // Sync with prop changes and verify authentication
+  useEffect(() => {
+    if (propUser) {
+      setInternalUser(propUser);
+    } else {
+      // Double-check authentication state if no user prop provided
+      if (AuthService.isAuthenticated()) {
+        const user = AuthService.getUser();
+        setInternalUser(user);
+      } else {
+        setInternalUser(null);
+      }
+    }
+  }, [propUser]);
+
+  // Refresh user state when location changes (helpful for OAuth redirects)
+  useEffect(() => {
+    const checkAuth = () => {
+      if (AuthService.isAuthenticated() && !internalUser) {
+        const user = AuthService.getUser();
+        setInternalUser(user);
+      }
+    };
+    
+    checkAuth();
+  }, [location.pathname]);
 
   const handleUserMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -48,12 +74,13 @@ const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
     onLogout?.();
   };
 
+  const user = internalUser; // Use internal user state
+
   const navItems = [
     { label: 'Home', path: '/', icon: <Home sx={{ fontSize: 20 }} /> },
     { label: 'Dashboard', path: '/dashboard', icon: <Dashboard sx={{ fontSize: 20 }} /> },
     { label: 'Settings', path: '/settings', icon: <Settings sx={{ fontSize: 20 }} /> },
   ].filter(item => {
-    // Hide Home button when on dashboard
     if (item.path === '/' && location.pathname === '/dashboard') {
       return false;
     }
@@ -108,7 +135,7 @@ const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
             </Typography>
           </Box>
 
-          {/* Navigation - always show when not on login page */}
+          {/* Navigation */}
           {location.pathname !== '/login' && (
             <Box sx={{
               display: 'flex',
@@ -151,7 +178,6 @@ const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1, justifyContent: 'flex-end' }}>
             {user ? (
               <>
-                {/* User Status Chip */}
                 <Chip
                   label="Connected"
                   size="small"
@@ -163,7 +189,6 @@ const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
                   }}
                 />
 
-                {/* User Avatar and Menu */}
                 <IconButton onClick={handleUserMenuOpen} sx={{ p: 0 }}>
                   <Avatar
                     src={user.avatar}

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,17 +1,15 @@
+// frontend/src/components/layout/Layout.tsx
 import React from 'react';
 import { Box } from '@mui/material';
 import Header from './Header';
 import Footer from './Footer';
 import AnimatedBackground from '../ui/AnimatedBackground';
+import { User } from '../../utils/auth';
 
 interface LayoutProps {
   children: React.ReactNode;
   backgroundVariant?: 'default' | 'dashboard' | 'minimal';
-  user?: {
-    name: string;
-    avatar: string;
-    username: string;
-  } | null;
+  user?: User | null;
   onLogout?: () => void;
   showFooter?: boolean;
 }


### PR DESCRIPTION
##  Fix: Authentication State Persistence After Login

### Problem
After logout and re-login, the header incorrectly displayed "Connect GitHub" button even though the user was authenticated and repositories were loading successfully.

### Root Cause
Race condition in authentication state management - the App component rendered before checking authentication state, causing the Header to receive `null` user prop initially.

### Solution
- Added authentication state checking on app mount with loading state
- Implemented proper OAuth callback handling to immediately set user state
- Prevented UI rendering until authentication is verified

### Changes
- `frontend/src/App.tsx` - Added `checkAuthState()` function and loading state
- `frontend/src/components/layout/Header.tsx` - Enhanced auth state synchronization

### Testing
✅ Fresh login - correct user avatar displayed  
✅ Logout and re-login - no "Connect GitHub" button bug  
✅ Page refresh - auth state persists correctly  
✅ Session persistence - user remains logged in  

### Impact
**Before:** Inconsistent UI showing "Connect GitHub" when already authenticated  
**After:** Consistent auth state with proper user avatar and "Connected" status

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a full-page loading screen while authentication status is being checked.

* Refactor
  * Streamlined authentication flow with OAuth callback handling, improved error recovery, and clearer state transitions.
  * Unified user typing across app and layout components for consistency.
  * Simplified header navigation logic; the Home item is always visible.
  * Enhanced logout sequence with clearer state updates.

* Chores
  * Added diagnostic logging to trace authentication checks and outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->